### PR TITLE
Fix Obsolete comment on NodeObjectTypeExtensions.cs

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Extensions/NodeObjectTypeExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Extensions/NodeObjectTypeExtensions.cs
@@ -27,12 +27,12 @@ namespace HotChocolate.Types
             return new NodeDescriptor<T>(descriptor);
         }
 
-        [Obsolete("Use ImplementNode.")]
+        [Obsolete("Use ImplementsNode.")]
         public static INodeDescriptor AsNode(
             this IObjectTypeDescriptor descriptor) =>
             ImplementsNode(descriptor);
 
-        [Obsolete("Use ImplementNode.")]
+        [Obsolete("Use ImplementsNode.")]
         public static INodeDescriptor<T> AsNode<T>(
             this IObjectTypeDescriptor<T> descriptor) =>
             ImplementsNode<T>(descriptor);


### PR DESCRIPTION
Fix obsolete comment.

Set the correct name of the method to use instead of AsNode.